### PR TITLE
Removing example-env

### DIFF
--- a/gocd/environments/example-env.yaml
+++ b/gocd/environments/example-env.yaml
@@ -1,8 +1,0 @@
-environments:
-    replay-analyzer-env:
-        environment_variables:
-            # These values can be customized per-pipeline run
-            # by clicking the run button with a plus sign.
-            # If you'd like to generate encrypted values,
-            # please refer to the Quickstart Guide.
-            EXAMPLE_ENV_VAR: Example environment variable


### PR DESCRIPTION
This is the causing an error because `replay-analyzer-env` doesn't match the environment used by GoCD which is `session-replay-analyzer`. But since you don't currently use it, I thought it would be better to remove it since currently it only adds more unnecessary complexity to the configuration.