### PR TITLE
Switching project to internal-sentry in GoCD pipeline

### DIFF
--- a/gocd/pipelines/session-replay-analyzer.yaml
+++ b/gocd/pipelines/session-replay-analyzer.yaml
@@ -35,7 +35,7 @@ pipelines:
                 - script: |
                     /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
                     ${GO_REVISION_SESSION_REPLAY_ANALYZER_REPO} \
-                    sentryio \
+                    internal-sentry \
                     "us.gcr.io/internal-sentry/session-replay-analyzer"
       - deploy-canary:
           jobs:


### PR DESCRIPTION
Currently the `project` and `image_name` have conflicting projects set. This PR sets them both to internal-sentry.