### PR TITLE
fix(hc): allow healthcheck to return negative response

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express, { type Request, type Response } from 'express'
+import * as fs from 'fs'
 import * as playwright from 'playwright'
 import { runA11Y } from './accessibility'
 import { newPlayerPage } from './player'
@@ -30,7 +31,13 @@ app.get('/', (req, res) => {
 })
 
 app.get('/api/healthcheck/live', (req, res) => {
-  res.status(200).send('OK')
+  fs.access("/tmp/analyzer.down", fs.constants.F_OK, (err) => {
+    if (!err) {
+      res.status(502).send('Downfile Exists')
+    } else {
+      res.status(200).send('OK')
+    }
+  });
 })
 
 interface TypedRequest<T> extends Request {


### PR DESCRIPTION
This allows the healthcheck to return a negative response when `/tmp/analyzer.down` exists on the container.
This is required for [Traffic Director](https://cloud.google.com/traffic-director) in our non-SaaS environments (see https://github.com/getsentry/ops/pull/8468 for the k8s side of this).