### PR TITLE
feat: sentry capture errors

### DIFF
--- a/src/accessibility/index.ts
+++ b/src/accessibility/index.ts
@@ -83,8 +83,10 @@ async function runAxe (page: playwright.Page, timestamp: any): Promise<Accessibl
     console.timeEnd('violations')
     return violations
   } catch (e) {
-    // TODO: Handle axe-core errors.
-    console.log(e)
+    Sentry.captureException(e, (scope) => {
+      scope.setTag("page.url", page.url());
+      return scope;
+    });
     return []
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import { runA11Y } from './accessibility'
 import { newPlayerPage } from './player'
 import { newStorage } from './gcs'
 import * as Sentry from "@sentry/node";
-import {SENTRY_DSN, SENTRY_TRACE_SAMPLE_RATE, SENTRY_PROFILE_SAMPLE_RATE} from './config'
+import {SENTRY_DSN, SENTRY_TRACE_SAMPLE_RATE, SENTRY_PROFILE_SAMPLE_RATE, ENVIRONMENT} from './config'
 import { ProfilingIntegration } from "@sentry/profiling-node";
 
 const storage = newStorage()
@@ -13,6 +13,7 @@ const app = express()
 
 Sentry.init({
   dsn: SENTRY_DSN,
+  environment: ENVIRONMENT,
   integrations: [
       new Sentry.Integrations.Http({ tracing: true }),
       new Sentry.Integrations.Express({ app }),

--- a/src/gcs.ts
+++ b/src/gcs.ts
@@ -2,6 +2,7 @@ import { Storage } from '@google-cloud/storage'
 import { MockStorage, type IStorage } from 'mock-gcs'
 import {BUCKET_NAME, ENVIRONMENT} from './config'
 import zlib from 'zlib';
+import * as Sentry from "@sentry/node";
 
 function newStorage(): IStorage {
   if (ENVIRONMENT == "test") {
@@ -22,6 +23,11 @@ async function downloadFromFilename (storage: IStorage, filename: string): Promi
     const response = await storage.bucket(BUCKET_NAME).file(filename).download()
     return zlib.unzipSync(response[0]).toString()
   } catch (e) {
+    Sentry.captureException(e, (scope) => {
+      scope.setTag("fileName", filename);
+      scope.setTag("bucketName", BUCKET_NAME);
+      return scope;
+    });
     return '[]'
   }
 }


### PR DESCRIPTION
1. Provide Sentry with the environment so we can configure alerts only for `production`
2. Capture errors when trying to access GCS (add  bucket name and filename as tags)
3. Capture errors when calling axe-core